### PR TITLE
Fix for Ruby 2.4.1

### DIFF
--- a/lib/travis/settings/encrypted_column.rb
+++ b/lib/travis/settings/encrypted_column.rb
@@ -84,6 +84,7 @@ module Travis
       end
 
       def create_aes(mode = :encrypt, key, iv)
+        key = key[0, 32]
         aes = OpenSSL::Cipher::AES.new(256, :CBC)
 
         aes.send(mode)


### PR DESCRIPTION
OpenSSL has made this change: https://github.com/ruby/ruby/commit/ce635262f53b760284d56bb1027baebaaec175d1

It seems previously it has truncated our key ("Currently they just
truncate the input ..."), so this change should be non-breaking.